### PR TITLE
DOC-3482 Add the restriction note type for visibility restrictions

### DIFF
--- a/plugins/com.lumapps.html5/xsl/note.xsl
+++ b/plugins/com.lumapps.html5/xsl/note.xsl
@@ -20,6 +20,11 @@
             <xsl:apply-templates/>
         </div>
     </xsl:template>
+    <xsl:template match="*" mode="process.note.restriction">
+        <div class="box box--restriction">
+            <xsl:apply-templates/>
+        </div>
+    </xsl:template>
     
     <xsl:template match="*" mode="process.note.important">
         <div class="box box--info">


### PR DESCRIPTION
Technical writers are using the note type ‘remember’ incorrectly. The project was configured for the type to be used for indicating a visibility restriction. However, it is also misused to provide or remind of relevant information. 

To make note type selection more intuitive for writers, this change adds a 'restriction' note type configured in the product documentation project scheme and documentation portal CSS for visibility restrictions. 

The 'remember' type has been removed from the `note_types.ditamap` file of the product documentation project so that it can no longer be selected. The 'remember' type is kept in this project and in the portal CSS to avoid errors for writers that are not yet using the updated version of the product documentation project.

https://lumapps.atlassian.net/browse/DOC-3482